### PR TITLE
Version 2.0 Proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 packages
 pubspec.lock
 .pub
+doc

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 # redux.dart
 
-[Redux](http://redux.js.org/) for Dart using generics for
-typed Actions and State.
+[Redux](http://redux.js.org/) for Dart using generics for typed State.
+
+## Web Examples
+
+See the `example/` directory to for a few simple examples of the basics of Redux.
+
+To launch the examples in your browser:
+
+  1. Run `pub serve example` from this directory
+  2. Open [http://localhost:8080](http://localhost:8080)
+
+## Flutter Integration
+
+See the [flutter_redux](https://pub.dartlang.org/packages/flutter_redux) library for a set of Widgets custom made to work with Redux.
 
 ## Usage
 
@@ -10,37 +22,45 @@ import 'package:redux/redux.dart';
 
 // Create a Reducer with a State (int) and an Action (String)
 // Any dart object can be used for Action and State.
-class Counter extends Reducer<int, String> {
-  reduce(int state, String action) {
-    switch (action) {
-      case 'INCREMENT':
-        return state + 1;
-      case 'DECREMENT':
-        return state - 1;
-      default:
-        return state;
-    }
+int counterReducer(int state, action) {
+  switch (action) {
+    case 'INCREMENT':
+      return state + 1;
+    case 'DECREMENT':
+      return state - 1;
+    default:
+      return state;
   }
 }
 
 // A piece of middleware that will log all actions with a timestamp
 // to your console!
-class LoggingMiddleware implements Middleware<int, String> {
-  call(Store<int, String> store, String action, next) {
-    print('${new DateTime.now()}: $action');
-    
-    next(action);
-  }
+loggingMiddleware(Store<int> store, action, next) {
+  print('${new DateTime.now()}: $action');
+
+  next(action);
 }
 
-main() {
-  var reducer = new CounterReducer();
-  var middleware = new LoggingMiddleware();
-  var store = new Store<int, String>(reducer, initialState: 0, middleware: [middleware]);
 
+main() {
+  final store = new Store<int>(
+    reducer, 
+    initialState: 0, 
+    middleware: [loggingMiddleware],
+  );
+
+  // Render our State right away
   render(store.state);
+  
+  // Listen to store changes, and re-render when the state is updated
   store.onChange.listen(render);
 
+  // Attach a click handler to a button. When clicked, the `INCREMENT` action
+  // will be dispatched. It will then run through the reducer, updating the 
+  // state.
+  //
+  // After the state changes, the html will be re-rendered by our `onChange`
+  // listener above. 
   querySelector('#increment').onClick.listen((_) {
     store.dispatch('INCREMENT');
   });
@@ -49,10 +69,4 @@ main() {
 render(int state) {
   querySelector('#value').innerHtml = '${state}';
 }
-```
-
-see the `example/` directory for details.  To run:
-
-```
-pub serve example
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redux.dart
 
-[Redux](http://redux.js.org/) for Dart using generics for typed State.
+[Redux](http://redux.js.org/) for Dart using generics for typed State. For complete documentation, view the [API Docs](https://www.dartdocs.org/documentation/redux/latest/).
 
 ## Web Examples
 

--- a/example/combined_reducers/index.dart
+++ b/example/combined_reducers/index.dart
@@ -18,8 +18,8 @@ enum AppAction { increment, decrement }
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-class Counter extends Reducer<AppState, AppAction> {
-  reduce(AppState state, AppAction action) {
+class Counter extends Reducer<AppState> {
+  reduce(AppState state, dynamic action) {
     switch (action) {
       case AppAction.increment:
         return new AppState(state.count + 1, state.clickCount);
@@ -33,8 +33,8 @@ class Counter extends Reducer<AppState, AppAction> {
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-class ClickCounter extends Reducer<AppState, AppAction> {
-  reduce(AppState state, AppAction action) {
+class ClickCounter extends Reducer<AppState> {
+  reduce(AppState state, dynamic action) {
     switch (action) {
       case AppAction.increment:
         return new AppState(state.count, state.clickCount + 1);
@@ -50,8 +50,8 @@ main() {
   // Create a new reducer and store for the app.
   var reducer1 = new Counter();
   var reducer2 = new ClickCounter();
-  var combined = new CombinedReducer<AppState, AppAction>([reducer1, reducer2]);
-  var store = new Store<AppState, AppAction>(combined,
+  var combined = new CombinedReducer<AppState>([reducer1, reducer2]);
+  var store = new Store<AppState>(combined,
       initialState: new AppState(0, 0));
 
   render(store.state);

--- a/example/combined_reducers/index.dart
+++ b/example/combined_reducers/index.dart
@@ -11,6 +11,7 @@ render(AppState state) {
 class AppState {
   final int count;
   final int clickCount;
+
   AppState(this.count, this.clickCount);
 }
 
@@ -18,41 +19,40 @@ enum AppAction { increment, decrement }
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-class Counter extends Reducer<AppState> {
-  reduce(AppState state, dynamic action) {
-    switch (action) {
-      case AppAction.increment:
-        return new AppState(state.count + 1, state.clickCount);
-      case AppAction.decrement:
-        return new AppState(state.count - 1, state.clickCount);
-      default:
-        return state;
-    }
+AppState counterReducer(AppState state, action) {
+  switch (action) {
+    case AppAction.increment:
+      return new AppState(state.count + 1, state.clickCount);
+    case AppAction.decrement:
+      return new AppState(state.count - 1, state.clickCount);
+    default:
+      return state;
   }
 }
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-class ClickCounter extends Reducer<AppState> {
-  reduce(AppState state, dynamic action) {
-    switch (action) {
-      case AppAction.increment:
-        return new AppState(state.count, state.clickCount + 1);
-      case AppAction.decrement:
-        return new AppState(state.count, state.clickCount + 1);
-      default:
-        return state;
-    }
+AppState clickCounterReducer(AppState state, action) {
+  switch (action) {
+    case AppAction.increment:
+      return new AppState(state.count, state.clickCount + 1);
+    case AppAction.decrement:
+      return new AppState(state.count, state.clickCount + 1);
+    default:
+      return state;
   }
 }
 
 main() {
   // Create a new reducer and store for the app.
-  var reducer1 = new Counter();
-  var reducer2 = new ClickCounter();
-  var combined = new CombinedReducer<AppState>([reducer1, reducer2]);
-  var store = new Store<AppState>(combined,
-      initialState: new AppState(0, 0));
+  final combined = combineReducers<AppState>([
+    counterReducer,
+    clickCounterReducer,
+  ]);
+  final store = new Store<AppState>(
+    combined,
+    initialState: new AppState(0, 0),
+  );
 
   render(store.state);
   store.onChange.listen(render);

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Redux Examples</title>
+</head>
+<body>
+<h1>Redux Web Examples</h1>
+<ul>
+    <li><a href="/vanilla_counter">Vanilla counter example</a></li>
+    <li><a href="/combined_reducers">Combined reducers example</a></li>
+    <li><a href="/middleware">Middleware example</a></li>
+</ul>
+</body>
+</html>

--- a/example/middleware/index.dart
+++ b/example/middleware/index.dart
@@ -9,8 +9,8 @@ render(int state) {
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-class Counter extends Reducer<int, String> {
-  reduce(int state, String action) {
+class Counter extends Reducer<int> {
+  reduce(int state, dynamic action) {
     switch (action) {
       case 'INCREMENT':
         return state + 1;
@@ -24,8 +24,8 @@ class Counter extends Reducer<int, String> {
 
 // A piece of middleware that will log all actions with a timestamp to your
 // console!
-class LoggingMiddleware implements Middleware<int, String> {
-  call(Store<int, String> store, String action, next) {
+class LoggingMiddleware implements Middleware<int> {
+  call(Store<int> store, dynamic action, next) {
     print('${new DateTime.now()}: $action');
 
     next(action);
@@ -34,9 +34,9 @@ class LoggingMiddleware implements Middleware<int, String> {
 
 main() {
   // Create a new reducer and store for the app.
-  var store = new Store<int, String>(new Counter(),
+  var store = new Store<int>(new Counter(),
       initialState: 0,
-      middleware: <Middleware<int, String>>[new LoggingMiddleware()]);
+      middleware: <Middleware<int>>[new LoggingMiddleware()]);
 
   render(store.state);
   store.onChange.listen(render);

--- a/example/middleware/index.dart
+++ b/example/middleware/index.dart
@@ -9,34 +9,32 @@ render(int state) {
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-class Counter extends Reducer<int> {
-  reduce(int state, dynamic action) {
-    switch (action) {
-      case 'INCREMENT':
-        return state + 1;
-      case 'DECREMENT':
-        return state - 1;
-      default:
-        return state;
-    }
+int counterReducer(int state, action) {
+  switch (action) {
+    case 'INCREMENT':
+      return state + 1;
+    case 'DECREMENT':
+      return state - 1;
+    default:
+      return state;
   }
 }
 
 // A piece of middleware that will log all actions with a timestamp to your
 // console!
-class LoggingMiddleware implements Middleware<int> {
-  call(Store<int> store, dynamic action, next) {
-    print('${new DateTime.now()}: $action');
+loggingMiddleware(Store<int> store, action, next) {
+  print('${new DateTime.now()}: $action');
 
-    next(action);
-  }
+  next(action);
 }
 
 main() {
   // Create a new reducer and store for the app.
-  var store = new Store<int>(new Counter(),
-      initialState: 0,
-      middleware: <Middleware<int>>[new LoggingMiddleware()]);
+  final store = new Store<int>(
+    counterReducer,
+    initialState: 0,
+    middleware: <Middleware<int>>[loggingMiddleware],
+  );
 
   render(store.state);
   store.onChange.listen(render);

--- a/example/vanilla_counter/index.dart
+++ b/example/vanilla_counter/index.dart
@@ -9,8 +9,8 @@ render(int state) {
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-class Counter extends Reducer<int, String> {
-  reduce(int state, String action) {
+class Counter extends Reducer<int> {
+  reduce(int state, dynamic action) {
     switch (action) {
       case 'INCREMENT':
         return state + 1;

--- a/example/vanilla_counter/index.dart
+++ b/example/vanilla_counter/index.dart
@@ -9,23 +9,20 @@ render(int state) {
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-class Counter extends Reducer<int> {
-  reduce(int state, dynamic action) {
-    switch (action) {
-      case 'INCREMENT':
-        return state + 1;
-      case 'DECREMENT':
-        return state - 1;
-      default:
-        return state;
-    }
+int counterReducer(int state, action) {
+  switch (action) {
+    case 'INCREMENT':
+      return state + 1;
+    case 'DECREMENT':
+      return state - 1;
+    default:
+      return state;
   }
 }
 
 main() {
   // Create a new reducer and store for the app.
-  var reducer = new Counter();
-  var store = new Store(reducer, initialState: 0);
+  final store = new Store(counterReducer, initialState: 0);
 
   render(store.state);
   store.onChange.listen(render);

--- a/test/middleware_test.dart
+++ b/test/middleware_test.dart
@@ -4,24 +4,35 @@ import 'utils.dart';
 
 main() {
   group('middleware', () {
+    test('can be defined as a Class', () {
+      expect(
+        new IncrementMiddleware(),
+        new isInstanceOf<Middleware<String>>(),
+      );
+    });
+
     test('are invoked by the store', () {
-      var reducer = new StringReducer();
-      var middleware = new IncrementMiddleware();
-      var store =
-          new Store(reducer, initialState: 'hello', middleware: [middleware]);
+      final middleware = new IncrementMiddleware();
+      final store = new Store(
+        stringReducer,
+        initialState: 'hello',
+        middleware: [middleware],
+      );
       store.dispatch('test');
       expect(middleware.counter, equals(1));
     });
 
     test('are applied in the correct order', () {
-      var reducer = new StringReducer();
-      var middleware1 = new IncrementMiddleware();
-      var middleware2 = new IncrementMiddleware();
-      var middleware = [middleware1, middleware2];
-      var store =
-          new Store(reducer, initialState: 'hello', middleware: middleware);
+      final middleware1 = new IncrementMiddleware();
+      final middleware2 = new IncrementMiddleware();
+      final middleware = [middleware1, middleware2];
+      final store = new Store(
+        stringReducer,
+        initialState: 'hello',
+        middleware: middleware,
+      );
 
-      var order = [];
+      final order = [];
       middleware1.invocations.listen((action) => order.add('first'));
       middleware2.invocations.listen((action) => order.add('second'));
 
@@ -31,14 +42,16 @@ main() {
     });
 
     test('actions can be dispatched multiple times', () {
-      var reducer = new StringReducer();
-      var middleware1 = new ExtraActionIncrementMiddleware();
-      var middleware2 = new IncrementMiddleware();
-      var middleware = [middleware1, middleware2];
-      var store =
-          new Store(reducer, initialState: 'hello', middleware: middleware);
+      final middleware1 = new ExtraActionIncrementMiddleware();
+      final middleware2 = new IncrementMiddleware();
+      final middleware = [middleware1, middleware2];
+      final store = new Store(
+        stringReducer,
+        initialState: 'hello',
+        middleware: middleware,
+      );
 
-      var order = [];
+      final order = [];
       middleware1.invocations.listen((action) => order.add('first'));
       middleware2.invocations.listen((action) => order.add('second'));
 
@@ -49,14 +62,40 @@ main() {
     });
 
     test('actions can be dispatched through entire chain', () {
-      var reducer = new StringReducer();
-      var middleware1 = new ExtraActionIfDispatchedIncrementMiddleware();
-      var middleware2 = new IncrementMiddleware();
-      var middleware = [middleware1, middleware2];
-      var store =
-          new Store(reducer, initialState: 'hello', middleware: middleware);
+      final middleware1 = new ExtraActionIfDispatchedIncrementMiddleware();
+      final middleware2 = new IncrementMiddleware();
+      final middleware = [middleware1, middleware2];
+      final store = new Store(
+        stringReducer,
+        initialState: 'hello',
+        middleware: middleware,
+      );
 
-      var order = [];
+      final order = [];
+      middleware1.invocations.listen((action) => order.add('first'));
+      middleware2.invocations.listen((action) => order.add('second'));
+
+      store.dispatch('test');
+
+      expect(order[0], equals('first'));
+      expect(order[1], equals('second'));
+      expect(order[2], equals('first'));
+      expect(order[3], equals('second'));
+
+      expect(middleware1.counter, equals(2));
+    });
+
+    test('actions can be dispatched through entire chain', () {
+      final middleware1 = new ExtraActionIfDispatchedIncrementMiddleware();
+      final middleware2 = new IncrementMiddleware();
+      final middleware = [middleware1, middleware2];
+      final store = new Store(
+        stringReducer,
+        initialState: 'hello',
+        middleware: middleware,
+      );
+
+      final order = [];
       middleware1.invocations.listen((action) => order.add('first'));
       middleware2.invocations.listen((action) => order.add('second'));
 

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -5,17 +5,26 @@ import 'utils.dart';
 main() {
   group('store', () {
     test('calls the reducer when an action is fired', () {
-      var reducer = new StringReducer();
-      var store = new Store(reducer, initialState: 'Hello');
-      var action = 'test';
+      final store = new Store(stringReducer, initialState: 'Hello');
+      final action = 'test';
       store.dispatch(action);
       expect(store.state, equals(action));
     });
 
+    test('reducers can be a Class', () {
+      expect(
+        new StringReducer(),
+        new isInstanceOf<Reducer<String>>(),
+      );
+    });
+
     test('when two reducers are combined, each reducer is invoked.', () {
-      var combinedReducer =
-          new CombinedReducer([new Reducer1(), new Reducer2()]);
-      var store = new Store(combinedReducer, initialState: 'hello');
+      final combinedReducer = combineReducers<String>([
+        reducer1,
+        reducer2,
+      ]);
+
+      final store = new Store(combinedReducer, initialState: 'hello');
       expect(store.state, equals('hello'));
       store.dispatch('helloReducer1');
       expect(store.state, equals('reducer 1 reporting'));
@@ -24,17 +33,21 @@ main() {
     });
 
     test('canceled subscriber should not be notified', () {
-      bool subscriber1Called = false;
-      bool subscriber2Called = false;
+      var subscriber1Called = false;
+      var subscriber2Called = false;
+      final store = new Store(
+        stringReducer,
+        initialState: 'hello',
+        syncStream: true,
+      );
+      final subscription = store.onChange.listen((String state) {
+        subscriber2Called = true;
+      });
 
-      var reducer = new StringReducer();
-      var store = new Store(reducer, initialState: 'hello', syncStream: true);
       store.onChange.listen((String state) {
         subscriber1Called = true;
       });
-      var subscription = store.onChange.listen((String state) {
-        subscriber2Called = true;
-      });
+
       subscription.cancel();
       store.dispatch("action");
       expect(subscriber1Called, isTrue);
@@ -42,10 +55,10 @@ main() {
     });
 
     test('store emits current state to subscribers', () {
-      var reducer = new StringReducer();
-      var action = 'test';
+      final action = 'test';
       var stateFromOnChangeListener = 'incorrectState';
-      var store = new Store(reducer, initialState: 'hello', syncStream: true);
+      final store =
+          new Store(stringReducer, initialState: 'hello', syncStream: true);
       store.onChange.listen((state) => stateFromOnChangeListener = state);
       store.dispatch(action);
       expect(stateFromOnChangeListener, equals(action));

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,32 +1,32 @@
 import 'package:redux/redux.dart';
 import 'dart:async';
 
-class Reducer1 implements Reducer<String, String> {
-  String reduce(String state, String action) {
+class Reducer1 implements Reducer<String> {
+  String reduce(String state, dynamic action) {
     if (action == 'helloReducer1') return 'reducer 1 reporting';
     return state;
   }
 }
 
-class Reducer2 implements Reducer<String, String> {
-  String reduce(String state, String action) {
+class Reducer2 implements Reducer<String> {
+  String reduce(String state, dynamic action) {
     if (action == 'helloReducer2') return 'reducer 2 reporting';
     return state;
   }
 }
 
-class StringReducer implements Reducer<String, String> {
-  String reduce(String state, String action) {
+class StringReducer implements Reducer<String> {
+  String reduce(String state, dynamic action) {
     return action;
   }
 }
 
-class IncrementMiddleware implements Middleware<int, String> {
+class IncrementMiddleware implements Middleware<int> {
   int counter = 0;
   StreamController<String> _invocationsController =
       new StreamController.broadcast(sync: true);
   Stream<String> get invocations => _invocationsController.stream;
-  call(Store<int, String> store, String action, NextDispatcher next) {
+  call(Store<int> store, dynamic action, NextDispatcher next) {
     _invocationsController.add(action);
     counter += 1;
     next(action);
@@ -34,7 +34,7 @@ class IncrementMiddleware implements Middleware<int, String> {
 }
 
 class ExtraActionIncrementMiddleware extends IncrementMiddleware {
-  call(Store<int, String> store, String action, NextDispatcher next) {
+  call(Store<int> store, dynamic action, NextDispatcher next) {
     _invocationsController.add(action);
     counter += 1;
     next(action);
@@ -45,7 +45,7 @@ class ExtraActionIncrementMiddleware extends IncrementMiddleware {
 class ExtraActionIfDispatchedIncrementMiddleware extends IncrementMiddleware {
   bool hasDispatched = false;
 
-  call(Store<int, String> store, String action, NextDispatcher next) {
+  call(Store<int> store, dynamic action, NextDispatcher next) {
     _invocationsController.add(action);
     counter += 1;
     next(action);

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,32 +1,31 @@
 import 'package:redux/redux.dart';
 import 'dart:async';
 
-class Reducer1 implements Reducer<String> {
-  String reduce(String state, dynamic action) {
-    if (action == 'helloReducer1') return 'reducer 1 reporting';
-    return state;
-  }
+String reducer1(String state, action) {
+  if (action == 'helloReducer1') return 'reducer 1 reporting';
+  return state;
 }
 
-class Reducer2 implements Reducer<String> {
-  String reduce(String state, dynamic action) {
-    if (action == 'helloReducer2') return 'reducer 2 reporting';
-    return state;
-  }
+String reducer2(String state, action) {
+  if (action == 'helloReducer2') return 'reducer 2 reporting';
+  return state;
 }
 
-class StringReducer implements Reducer<String> {
-  String reduce(String state, dynamic action) {
-    return action;
-  }
+String stringReducer(String state, action) => action is String ? action : '';
+
+class StringReducer extends ReducerClass<String> {
+  @override
+  String call(String state, action) => stringReducer(state, action);
 }
 
-class IncrementMiddleware implements Middleware<int> {
+class IncrementMiddleware extends MiddlewareClass<String> {
   int counter = 0;
   StreamController<String> _invocationsController =
       new StreamController.broadcast(sync: true);
+
   Stream<String> get invocations => _invocationsController.stream;
-  call(Store<int> store, dynamic action, NextDispatcher next) {
+
+  call(Store<String> store, action, NextDispatcher next) {
     _invocationsController.add(action);
     counter += 1;
     next(action);
@@ -34,7 +33,7 @@ class IncrementMiddleware implements Middleware<int> {
 }
 
 class ExtraActionIncrementMiddleware extends IncrementMiddleware {
-  call(Store<int> store, dynamic action, NextDispatcher next) {
+  call(Store<String> store, action, NextDispatcher next) {
     _invocationsController.add(action);
     counter += 1;
     next(action);
@@ -45,7 +44,7 @@ class ExtraActionIncrementMiddleware extends IncrementMiddleware {
 class ExtraActionIfDispatchedIncrementMiddleware extends IncrementMiddleware {
   bool hasDispatched = false;
 
-  call(Store<int> store, dynamic action, NextDispatcher next) {
+  call(Store<String> store, action, NextDispatcher next) {
     _invocationsController.add(action);
     counter += 1;
     next(action);


### PR DESCRIPTION
Hey hey :) It was cool meeting you in Munich last year, hope all is well!

I've been using Redux a bit more and would like to suggest a couple of changes to this library to make it more slightly flexible yet still "as simple as possible."

Since these would be breaking changes, I'd propose it as a 2.0 release.

Overall, if this isn't your thang, honestly no worries at all. I'd be happy to publish it as a separate package, but thought it'd be cool to try to keep all the number of Redux implementations in DartLand as small as possible, and see what your thoughts are.

Now, I know you didn't want to change to typedef's in my first PR, but hear me out :) This new version would allow us to have our cake and eat it too: If users want to use functions for reducers and middleware, they can. If they want to use classes, they can!

Also, I was trying to implement Redux DevTools, but I was unsuccessful due to the typing of `Action`, because Store Enhancers need to be able to `dispatch` their own actions. Therefore, I removed it. I had this exact constraint in a Java version of Redux I'd written and and actually removed this Generic constraint in that lib due to the constraint.

Proposed changes:

  - Added a bunch of docs and did just a bit of code cleanup.
  - *Remove the typing of `Action`* - If `Action` is a typed parameter, it prevents any type of Store Enhancer (such as Redux Dev Tools) from dispatching their own actions. In code, this means `class Store<State, Action>` becomes `class Store<State>`.
  - *Change Reducer to Typedef with Class fallback* -- this introduces `typedef State Reducer<State>(State state, dynamic action);` and changes `class Reducer<State, Action>` to `abstract class ReducerClass<State>`. This would require only a small change to code, including extending the new class and renaming `reduce` to `call`.
  - *Change Middleware to Typedef with Class fallback* -- this introduces `typedef void Middleware<State>(Store<State> store, dynamic action, NextDispatcher next);` and changes `class Middleware<State, Action>` to `abstract class MiddlewareClass<State>`. For middleware, this should be an almost transparent change, as all they'd have to do is extend `MiddlewareClass` instead of `Middleware`.
  - Add `teardown` method, which `close`s the StreamController and nulls out the state. Needed in case someone wanted to stop using the store during the app lifecycle.

Lemme know whatcha think and if you have suggestions!