### PR TITLE
Add CI support to the project to verify tests, dartanalyzer, and dartfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: dart
+sudo: false
+dart:
+- stable
+- dev
+with_content_shell: false
+dart_task:
+- test: --platform vm
+- dartanalyzer: --fatal-warnings lib
+- dartfmt


### PR DESCRIPTION
First go at a Travis file. It includes tests, dartanalyzer, and dartfmt verification. Closes #5 