### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ loggingMiddleware(Store<int> store, action, NextDispatcher next) {
 
 main() {
   final store = new Store<int>(
-    reducer, 
+    counterReducer, 
     initialState: 0, 
     middleware: [loggingMiddleware],
   );


### PR DESCRIPTION
Just a minor fix, the method name is `counterReducer`?