### PR TITLE
Add `distinct` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ import 'package:redux/redux.dart';
 // update the state of your application.
 enum Actions {
   increment,
-  decrement
+  decrement,
 }
 
 // Create a Reducer. A reducer is a pure function that takes the 
@@ -25,9 +25,9 @@ enum Actions {
 // side-effects, such as making an HTTP request or logging messages
 // to a console. For that, use Middleware.
 int counterReducer(int state, action) {
-  if (action is Actions.increment) {
+  if (action == Actions.increment) {
     return state + 1;
-  } else if (action is Actions.decrement) {
+  } else if (action == Actions.decrement) {
     return state - 1;
   }
   
@@ -115,7 +115,9 @@ To launch the examples in your browser:
 
 ## Dev Tools
 
-The [redux_dev_tools](https://pub.dartlang.org/packages/redux_dev_tools) library allows you to create a `DevToolsStore` during dev mode in place of a normal Redux `Store`. This `DevToolsStore` will act exactly like a normal `Store` at first, with one catch: It will allow you to travel back and forth throughout the State of your application!
+The [redux_dev_tools](https://pub.dartlang.org/packages/redux_dev_tools) library allows you to create a `DevToolsStore` during dev mode in place of a normal Redux `Store`. 
+
+This `DevToolsStore` will act exactly like a normal `Store` at first. However, it will also allow you to travel back and forth throughout the States of your app or recompute the State of your app by replaying all actions through your reducers. This works perfectly with Hot Reloading!
 
 You can combine the `DevToolsStore` with your own UI to travel in time, or use one of the existing options for the platform you're working with:
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,4 @@
 analyzer:
-  strong-mode: true
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false

--- a/example/combined_reducers/index.dart
+++ b/example/combined_reducers/index.dart
@@ -1,9 +1,9 @@
-import 'dart:html';
 import 'dart:async';
+import 'dart:html';
 
 import 'package:redux/redux.dart';
 
-render(AppState state) {
+void render(AppState state) {
   querySelector('#value').innerHtml = '${state.count}';
   querySelector('#clickValue').innerHtml = '${state.clickCount}';
 }
@@ -19,31 +19,31 @@ enum AppAction { increment, decrement }
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-AppState counterReducer(AppState state, action) {
-  switch (action) {
-    case AppAction.increment:
-      return new AppState(state.count + 1, state.clickCount);
-    case AppAction.decrement:
-      return new AppState(state.count - 1, state.clickCount);
-    default:
-      return state;
+AppState counterReducer(AppState state, dynamic action) {
+  if (action == AppAction.increment) {
+    return new AppState(state.count + 1, state.clickCount);
   }
+  if (action == AppAction.decrement) {
+    return new AppState(state.count - 1, state.clickCount);
+  }
+
+  return state;
 }
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-AppState clickCounterReducer(AppState state, action) {
-  switch (action) {
-    case AppAction.increment:
-      return new AppState(state.count, state.clickCount + 1);
-    case AppAction.decrement:
-      return new AppState(state.count, state.clickCount + 1);
-    default:
-      return state;
+AppState clickCounterReducer(AppState state, dynamic action) {
+  if (action == AppAction.increment) {
+    return new AppState(state.count, state.clickCount + 1);
   }
+  if (action == AppAction.decrement) {
+    return new AppState(state.count, state.clickCount + 1);
+  }
+
+  return state;
 }
 
-main() {
+void main() {
   // Create a new reducer and store for the app.
   final combined = combineReducers<AppState>([
     counterReducer,
@@ -66,11 +66,13 @@ main() {
   });
 
   querySelector('#incrementIfOdd').onClick.listen((_) {
-    if (store.state.count % 2 != 0) store.dispatch(AppAction.increment);
+    if (store.state.count % 2 != 0) {
+      store.dispatch(AppAction.increment);
+    }
   });
 
   querySelector('#incrementAsync').onClick.listen((_) {
-    new Future.delayed(new Duration(milliseconds: 1000)).then((_) {
+    new Future<Null>.delayed(new Duration(milliseconds: 1000)).then((_) {
       store.dispatch(AppAction.increment);
     });
   });

--- a/example/middleware/index.dart
+++ b/example/middleware/index.dart
@@ -1,34 +1,35 @@
-import 'dart:html';
 import 'dart:async';
+import 'dart:html';
 
 import 'package:redux/redux.dart';
 
-render(int state) {
-  querySelector('#value').innerHtml = '${state}';
+void render(int state) {
+  querySelector('#value').innerHtml = '$state';
 }
+
+enum Actions { increment, decrement }
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-int counterReducer(int state, action) {
-  switch (action) {
-    case 'INCREMENT':
-      return state + 1;
-    case 'DECREMENT':
-      return state - 1;
-    default:
-      return state;
+int counterReducer(int state, dynamic action) {
+  if (action == Actions.increment) {
+    return state + 1;
+  } else if (action == Actions.decrement) {
+    return state - 1;
   }
+
+  return state;
 }
 
 // A piece of middleware that will log all actions with a timestamp to your
 // console!
-loggingMiddleware(Store<int> store, action, NextDispatcher next) {
+void loggingMiddleware(Store<int> store, dynamic action, NextDispatcher next) {
   print('${new DateTime.now()}: $action');
 
   next(action);
 }
 
-main() {
+void main() {
   // Create a new reducer and store for the app.
   final store = new Store<int>(
     counterReducer,
@@ -40,20 +41,22 @@ main() {
   store.onChange.listen(render);
 
   querySelector('#increment').onClick.listen((_) {
-    store.dispatch('INCREMENT');
+    store.dispatch(Actions.increment);
   });
 
   querySelector('#decrement').onClick.listen((_) {
-    store.dispatch('DECREMENT');
+    store.dispatch(Actions.decrement);
   });
 
   querySelector('#incrementIfOdd').onClick.listen((_) {
-    if (store.state % 2 != 0) store.dispatch('INCREMENT');
+    if (store.state % 2 != 0) {
+      store.dispatch(Actions.increment);
+    }
   });
 
   querySelector('#incrementAsync').onClick.listen((_) {
-    new Future.delayed(new Duration(milliseconds: 1000)).then((_) {
-      store.dispatch('INCREMENT');
+    new Future<Null>.delayed(new Duration(milliseconds: 1000)).then((_) {
+      store.dispatch(Actions.increment);
     });
   });
 }

--- a/example/vanilla_counter/index.dart
+++ b/example/vanilla_counter/index.dart
@@ -1,26 +1,27 @@
-import 'dart:html';
 import 'dart:async';
+import 'dart:html';
 
 import 'package:redux/redux.dart';
 
-render(int state) {
-  querySelector('#value').innerHtml = '${state}';
+void render(int state) {
+  querySelector('#value').innerHtml = '$state';
 }
+
+enum Actions { increment, decrement }
 
 // Create a Reducer with a State (int) and an Action (String) Any dart object
 // can be used for Action and State.
-int counterReducer(int state, action) {
-  switch (action) {
-    case 'INCREMENT':
-      return state + 1;
-    case 'DECREMENT':
-      return state - 1;
-    default:
-      return state;
+int counterReducer(int state, dynamic action) {
+  if (action == Actions.increment) {
+    return state + 1;
+  } else if (action == Actions.decrement) {
+    return state - 1;
   }
+
+  return state;
 }
 
-main() {
+void main() {
   // Create a new reducer and store for the app.
   final store = new Store(counterReducer, initialState: 0);
 
@@ -28,20 +29,22 @@ main() {
   store.onChange.listen(render);
 
   querySelector('#increment').onClick.listen((_) {
-    store.dispatch('INCREMENT');
+    store.dispatch(Actions.increment);
   });
 
   querySelector('#decrement').onClick.listen((_) {
-    store.dispatch('DECREMENT');
+    store.dispatch(Actions.decrement);
   });
 
   querySelector('#incrementIfOdd').onClick.listen((_) {
-    if (store.state % 2 != 0) store.dispatch('INCREMENT');
+    if (store.state % 2 != 0) {
+      store.dispatch(Actions.increment);
+    }
   });
 
   querySelector('#incrementAsync').onClick.listen((_) {
-    new Future.delayed(new Duration(milliseconds: 1000)).then((_) {
-      store.dispatch('INCREMENT');
+    new Future<Null>.delayed(new Duration(milliseconds: 1000)).then((_) {
+      store.dispatch(Actions.increment);
     });
   });
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -12,9 +12,7 @@ class ReducerBinding<State, Action> {
 
   ReducerBinding(this.reducer);
 
-  bool handlesAction(dynamic action) {
-    return action is Action;
-  }
+  bool handlesAction(dynamic action) => action is Action;
 }
 
 /// A convenience function for binding Reducers to Actions of a given Type. This
@@ -111,7 +109,7 @@ class ReducerBinding<State, Action> {
 /// ```
 Reducer<State> combineTypedReducers<State>(
     List<ReducerBinding<State, dynamic>> bindings) {
-  return (State state, action) {
+  return (State state, dynamic action) {
     return bindings.fold(state, (currentState, binder) {
       if (binder.handlesAction(action)) {
         return binder.reducer(state, action);
@@ -135,9 +133,7 @@ class MiddlewareBinding<State, Action> {
 
   MiddlewareBinding(this.middleware);
 
-  bool handlesAction(dynamic action) {
-    return action is Action;
-  }
+  bool handlesAction(dynamic action) => action is Action;
 }
 
 /// A convenience function for binding a piece of Middleware to an Action
@@ -239,7 +235,8 @@ class MiddlewareBinding<State, Action> {
 List<Middleware<State>> combineTypedMiddleware<State>(
     List<MiddlewareBinding<State, dynamic>> bindings) {
   return bindings
-      .map((binder) => (Store<State> store, action, NextDispatcher next) {
+      .map((binder) =>
+          (Store<State> store, dynamic action, NextDispatcher next) {
             if (binder.handlesAction(action)) {
               binder.middleware(store, action, next);
             } else {

--- a/test/middleware_test.dart
+++ b/test/middleware_test.dart
@@ -2,12 +2,12 @@ import 'package:redux/redux.dart';
 import 'package:test/test.dart';
 import 'test_data.dart';
 
-main() {
-  group('middleware', () {
+void main() {
+  group('Middleware', () {
     test('can be defined as a Class', () {
       expect(
         new IncrementMiddleware(),
-        new isInstanceOf<Middleware<String>>(),
+        const isInstanceOf<Middleware<String>>(),
       );
     });
 
@@ -32,7 +32,7 @@ main() {
         middleware: middleware,
       );
 
-      final order = [];
+      final order = <String>[];
       middleware1.invocations.listen((action) => order.add('first'));
       middleware2.invocations.listen((action) => order.add('second'));
 
@@ -51,7 +51,7 @@ main() {
         middleware: middleware,
       );
 
-      final order = [];
+      final order = <String>[];
       middleware1.invocations.listen((action) => order.add('first'));
       middleware2.invocations.listen((action) => order.add('second'));
 
@@ -71,7 +71,7 @@ main() {
         middleware: middleware,
       );
 
-      final order = [];
+      final order = <String>[];
       middleware1.invocations.listen((action) => order.add('first'));
       middleware2.invocations.listen((action) => order.add('second'));
 
@@ -95,7 +95,7 @@ main() {
         middleware: middleware,
       );
 
-      final order = [];
+      final order = <String>[];
       middleware1.invocations.listen((action) => order.add('first'));
       middleware2.invocations.listen((action) => order.add('second'));
 

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -2,8 +2,8 @@ import 'package:redux/redux.dart';
 import 'package:test/test.dart';
 import 'test_data.dart';
 
-main() {
-  group('store', () {
+void main() {
+  group('Store', () {
     test('calls the reducer when an action is fired', () {
       final store = new Store(stringReducer, initialState: 'Hello');
       final action = 'test';
@@ -14,7 +14,7 @@ main() {
     test('reducers can be a Class', () {
       expect(
         new StringReducer(),
-        new isInstanceOf<Reducer<String>>(),
+        const isInstanceOf<Reducer<String>>(),
       );
     });
 
@@ -35,19 +35,40 @@ main() {
       });
 
       subscription.cancel();
-      store.dispatch("action");
+      store.dispatch('action');
       expect(subscriber1Called, isTrue);
       expect(subscriber2Called, isFalse);
     });
 
     test('store emits current state to subscribers', () {
       final action = 'test';
-      var stateFromOnChangeListener = 'incorrectState';
-      final store =
-          new Store(stringReducer, initialState: 'hello', syncStream: true);
-      store.onChange.listen((state) => stateFromOnChangeListener = state);
+      final states = <String>[];
+      final store = new Store<String>(
+        stringReducer,
+        initialState: 'hello',
+        syncStream: true,
+      );
+      store.onChange.listen((state) => states.add(state));
+
+      // Dispatch two actions. Both should be emitted by default.
       store.dispatch(action);
-      expect(stateFromOnChangeListener, equals(action));
+      store.dispatch(action);
+
+      expect(states, <String>[action, action]);
+    });
+
+    test('store does not emit an onChange if distinct', () {
+      final action = 'test';
+      final states = <String>[];
+      final store = new Store<String>(stringReducer,
+          initialState: 'hello', syncStream: true, distinct: true);
+      store.onChange.listen((state) => states.add(state));
+
+      // Dispatch two actions. Only one should be emitted b/c distinct is true
+      store.dispatch(action);
+      store.dispatch(action);
+
+      expect(states, <String>[action]);
     });
   });
 }

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -1,43 +1,55 @@
-import 'package:redux/redux.dart';
 import 'dart:async';
+import 'package:redux/redux.dart';
 
-String reducer1(String state, action) {
-  if (action == 'helloReducer1') return 'reducer 1 reporting';
+String reducer1(String state, dynamic action) {
+  if (action == 'helloReducer1') {
+    return 'reducer 1 reporting';
+  }
   return state;
 }
 
-String reducer2(String state, action) {
-  if (action == 'helloReducer2') return 'reducer 2 reporting';
+String reducer2(String state, dynamic action) {
+  if (action == 'helloReducer2') {
+    return 'reducer 2 reporting';
+  }
   return state;
 }
 
-const notFound = 'not found';
+const String notFound = 'not found';
 
-String stringReducer(String state, action) =>
+String stringReducer(String state, dynamic action) =>
     action is String ? action : notFound;
 
 class StringReducer extends ReducerClass<String> {
   @override
-  String call(String state, action) => stringReducer(state, action);
+  String call(String state, dynamic action) => stringReducer(state, action);
 }
 
 class IncrementMiddleware extends MiddlewareClass<String> {
   int counter = 0;
-  StreamController<String> _invocationsController =
-      new StreamController.broadcast(sync: true);
+  final _invocationsController =
+      new StreamController<String>.broadcast(sync: true);
 
   Stream<String> get invocations => _invocationsController.stream;
 
-  call(Store<String> store, action, NextDispatcher next) {
-    _invocationsController.add(action);
+  @override
+  void call(Store<String> store, dynamic action, NextDispatcher next) {
+    add(action);
     counter += 1;
     next(action);
+  }
+
+  void add(dynamic action) {
+    if (action is String) {
+      _invocationsController.add(action);
+    }
   }
 }
 
 class ExtraActionIncrementMiddleware extends IncrementMiddleware {
-  call(Store<String> store, action, NextDispatcher next) {
-    _invocationsController.add(action);
+  @override
+  void call(Store<String> store, dynamic action, NextDispatcher next) {
+    add(action);
     counter += 1;
     next(action);
     next('another action');
@@ -47,8 +59,9 @@ class ExtraActionIncrementMiddleware extends IncrementMiddleware {
 class ExtraActionIfDispatchedIncrementMiddleware extends IncrementMiddleware {
   bool hasDispatched = false;
 
-  call(Store<String> store, action, NextDispatcher next) {
-    _invocationsController.add(action);
+  @override
+  void call(Store<String> store, dynamic action, NextDispatcher next) {
+    add(action);
     counter += 1;
     next(action);
     if (!hasDispatched) {

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -2,15 +2,13 @@ import 'package:redux/redux.dart';
 import 'package:test/test.dart';
 import 'test_data.dart';
 
-main() {
+void main() {
   group('Combining Reducers', () {
-    final testAction1Reducer = (String state, TestAction1 action) {
-      return action.toString();
-    };
+    String testAction1Reducer(String state, TestAction1 action) =>
+        action.toString();
 
-    final testAction2Reducer = (String state, TestAction2 action) {
-      return action.toString();
-    };
+    String testAction2Reducer(String state, TestAction2 action) =>
+        action.toString();
 
     group('Type Safe Combinations', () {
       test('are invoked when they match the Type of the dispatched action', () {
@@ -23,10 +21,10 @@ main() {
         );
 
         store.dispatch(new TestAction1());
-        expect(store.state, contains("TestAction1"));
+        expect(store.state, contains('TestAction1'));
 
         store.dispatch(new TestAction2());
-        expect(store.state, contains("TestAction2"));
+        expect(store.state, contains('TestAction2'));
       });
 
       test('are not invoked if they do not handle the action type', () {
@@ -65,21 +63,21 @@ main() {
   });
 
   group('Typed Middleware', () {
-    final testAction1Middleware = (
+    void testAction1Middleware(
       Store<String> store,
       TestAction1 action,
       NextDispatcher next,
     ) {
-      next("testAction1Middleware called");
-    };
+      next('testAction1Middleware called');
+    }
 
-    final testAction2Middleware = (
+    void testAction2Middleware(
       Store<String> store,
       TestAction2 action,
       NextDispatcher next,
     ) {
-      next("testAction2Middleware called");
-    };
+      next('testAction2Middleware called');
+    }
 
     test('are invoked based on the type of action they accept', () {
       final store = new Store<String>(
@@ -92,10 +90,10 @@ main() {
       );
 
       store.dispatch(new TestAction1());
-      expect(store.state, "testAction1Middleware called");
+      expect(store.state, 'testAction1Middleware called');
 
       store.dispatch(new TestAction2());
-      expect(store.state, "testAction2Middleware called");
+      expect(store.state, 'testAction2Middleware called');
     });
 
     test(


### PR DESCRIPTION
If the `distinct` param set to true, the Store will not emit onChange events if the new State that is returned from your `reducer` in response to an Action is equal to the previous state.

Under the hood, it will use the `==` method from your State class to determine whether or not the two States are equal.

For fun, I've also added stricter analysis rules to improve the "health" score displayed by Pana on the Pub website, fixed a silly mistake in the README example, and updated the examples to reflect the README.

Example usage: `new Store(myReducer, distinct: true);`

/cc @johnbland-wf

Fixes #14.