### PR TITLE
2.1.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.0.3
+# 2.1.0
+
+  * Add the `distinct` option. If set to true, the Store will not emit onChange events if the new State that is returned from your [reducer] in response to an Action is equal to the previous state. False by default.
+
+# 2.0.4
 
   * Use absolute urls to fix broken links in documentation on Pub.
   

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ enum Actions {
 }
 
 // Create a Reducer. A reducer is a pure function that takes the 
-// current State (int) and the Action that was dispatched. It will
-// combine the two into a new state! After the state is updated,
-// the store will emit the update to the `onChange` stream.
+// current State (int) and the Action that was dispatched. It should
+// combine the two into a new state without mutating the state passed
+// in! After the state is updated, the store will emit the update to 
+// the `onChange` stream.
 // 
 // Because reducers are pure functions, they should not perform any 
 // side-effects, such as making an HTTP request or logging messages

--- a/example/combined_reducers/index.dart
+++ b/example/combined_reducers/index.dart
@@ -17,8 +17,15 @@ class AppState {
 
 enum AppAction { increment, decrement }
 
-// Create a Reducer with a State (int) and an Action (String) Any dart object
-// can be used for Action and State.
+// Create a Reducer. A reducer is a pure function that takes the
+// current State (int) and the Action that was dispatched. It should
+// combine the two into a new state without mutating the state passed
+// in! After the state is updated, the store will emit the update to
+// the `onChange` stream.
+//
+// Because reducers are pure functions, they should not perform any
+// side-effects, such as making an HTTP request or logging messages
+// to a console. For that, use Middleware.
 AppState counterReducer(AppState state, dynamic action) {
   if (action == AppAction.increment) {
     return new AppState(state.count + 1, state.clickCount);

--- a/example/middleware/index.dart
+++ b/example/middleware/index.dart
@@ -9,8 +9,15 @@ void render(int state) {
 
 enum Actions { increment, decrement }
 
-// Create a Reducer with a State (int) and an Action (String) Any dart object
-// can be used for Action and State.
+// Create a Reducer. A reducer is a pure function that takes the
+// current State (int) and the Action that was dispatched. It should
+// combine the two into a new state without mutating the state passed
+// in! After the state is updated, the store will emit the update to
+// the `onChange` stream.
+//
+// Because reducers are pure functions, they should not perform any
+// side-effects, such as making an HTTP request or logging messages
+// to a console. For that, use Middleware.
 int counterReducer(int state, dynamic action) {
   if (action == Actions.increment) {
     return state + 1;

--- a/example/vanilla_counter/index.dart
+++ b/example/vanilla_counter/index.dart
@@ -9,8 +9,15 @@ void render(int state) {
 
 enum Actions { increment, decrement }
 
-// Create a Reducer with a State (int) and an Action (String) Any dart object
-// can be used for Action and State.
+// Create a Reducer. A reducer is a pure function that takes the
+// current State (int) and the Action that was dispatched. It should
+// combine the two into a new state without mutating the state passed
+// in! After the state is updated, the store will emit the update to
+// the `onChange` stream.
+//
+// Because reducers are pure functions, they should not perform any
+// side-effects, such as making an HTTP request or logging messages
+// to a console. For that, use Middleware.
 int counterReducer(int state, dynamic action) {
   if (action == Actions.increment) {
     return state + 1;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ authors:
 - Brian Egan <brian@brianegan.com>
 description: Redux for Dart
 homepage: http://github.com/johnpryan/redux.dart
-version: 2.0.4
+version: 2.1.0
 
 dev_dependencies:
   browser: any


### PR DESCRIPTION
Hey hey -- this is the 2.1.0 version which includes the `distinct` option. Wanted to get your opinion on the changes.

In the last PR, I added `distinct` as a public field, but that requires us to bump to 3.0.0 b/c it isn't backwards compatible (folks implementing the Store would be forced to handle the change). 

In order to make this a non-breaking change, I've made distinct only a parameter of the constructor and create the `reduceAndNotify` NextDispatcher using it. 

The alternative would be to make `_distinct` a private field and use that in the `reduceAndNotify` function -- I don't think there's a big difference either way but wanted to run this by you before I ship it!