### PR TITLE
Get dat pub health score to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.1
+
+  * Ensure the repo is 100% healthy. 
+
 # 2.1.0
 
   * Add the `distinct` option. If set to true, the Store will not emit onChange events if the new State that is returned from your [reducer] in response to an Action is equal to the previous state. False by default.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,14 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+
+linter:
+  rules:
+    - cancel_subscriptions
+    - close_sinks
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - test_types_in_equals
+    - unrelated_type_equality_checks
+    - valid_regexps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,11 @@ authors:
 - Brian Egan <brian@brianegan.com>
 description: Redux for Dart
 homepage: http://github.com/johnpryan/redux.dart
-version: 2.1.0
+version: 2.1.1
+
+environment:
+  sdk: '>=1.24.0 <2.0.0'
 
 dev_dependencies:
-  browser: any
-  test: any
+  browser: '>=0.10.0+2 <0.11.0'
+  test: '>=0.12.24+2 <0.13.0'


### PR DESCRIPTION
We're at 90, we should get to 100 to demonstrate the quality and time we've put into this library!

After the last change, even with stricter analysis options, we did not see our health score improve. WAT!

So I did a few things:

  - Copied the lint rules from a project that has 100 health
  - Added the environment version constraint
  - Enforced version constraints on our `dev_dependencies` (I think this is actually where we lost our score: https://github.com/dart-lang/pana/blob/deb087e75e5e581427049e11a1068bc00f30fce6/lib/src/fitness.dart#L121)

Hopefully these changes will please the pana Gods and they will reward us with a 100% healthy score. 

I've also filed an issue with the pana repo to be able to run pana locally so we don't have to keep publishing minor versions until we see our changes work...
  
  
  