### PR TITLE
Specify explicit types for middleware in test/middleware_test.dart

### DIFF
--- a/test/middleware_test.dart
+++ b/test/middleware_test.dart
@@ -16,7 +16,7 @@ void main() {
       final store = new Store(
         stringReducer,
         initialState: 'hello',
-        middleware: [middleware],
+        middleware: <Middleware<String>>[middleware],
       );
       store.dispatch('test');
       expect(middleware.counter, equals(1));
@@ -25,7 +25,7 @@ void main() {
     test('are applied in the correct order', () {
       final middleware1 = new IncrementMiddleware();
       final middleware2 = new IncrementMiddleware();
-      final middleware = [middleware1, middleware2];
+      final middleware = <Middleware<String>>[middleware1, middleware2];
       final store = new Store(
         stringReducer,
         initialState: 'hello',
@@ -44,7 +44,7 @@ void main() {
     test('actions can be dispatched multiple times', () {
       final middleware1 = new ExtraActionIncrementMiddleware();
       final middleware2 = new IncrementMiddleware();
-      final middleware = [middleware1, middleware2];
+      final middleware = <Middleware<String>>[middleware1, middleware2];
       final store = new Store(
         stringReducer,
         initialState: 'hello',
@@ -64,7 +64,7 @@ void main() {
     test('actions can be dispatched through entire chain', () {
       final middleware1 = new ExtraActionIfDispatchedIncrementMiddleware();
       final middleware2 = new IncrementMiddleware();
-      final middleware = [middleware1, middleware2];
+      final middleware = <Middleware<String>>[middleware1, middleware2];
       final store = new Store(
         stringReducer,
         initialState: 'hello',
@@ -88,7 +88,7 @@ void main() {
     test('actions can be dispatched through entire chain', () {
       final middleware1 = new ExtraActionIfDispatchedIncrementMiddleware();
       final middleware2 = new IncrementMiddleware();
-      final middleware = [middleware1, middleware2];
+      final middleware = <Middleware<String>>[middleware1, middleware2];
       final store = new Store(
         stringReducer,
         initialState: 'hello',


### PR DESCRIPTION
Currently, the correct list types are inferred from the context.
However, an upcoming Dart 2.0 language change
(https://github.com/dart-lang/sdk/issues/32152) will break the
connection between callable classes and their corresponding function
types, which will prevent type inference from being able to infer
these list types anymore.

To prepare for the language change, we need to specify the list types
explicitly.