### PR TITLE
Added combineTypedReducers()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.dart_tool
 .idea
 .packages
 packages

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -250,3 +250,30 @@ Reducer<State> combineReducers<State>(Iterable<Reducer<State>> reducers) {
     return state;
   };
 }
+
+/// Defines a utility function that combines several typed reducers.
+///
+/// This is a thin wrapper around [combineReducers] that is useful when Dart 2
+/// cannot infer the proper types. This can arise in situations such as the
+/// following:
+///
+///     combineReducers(new List()
+///       ..addAll(Screen1Redux.contributeReducers())
+///       ..addAll(Screen2Redux.contributeReducers()));
+///
+///     class Screen1Redux {
+///       static List<TypedReducer<String, dynamic>> contributeReducers() => ...
+///     }
+///
+///     class Screen2Redux {
+///       static List<TypedReducer<String, dynamic>> contributeReducers() => ...
+///     }
+///
+/// In these types of cases, Dart 2 would give the following error:
+///
+///     Error: A value of type 'dart.core::List<#libnull::TypedReducer<dart.core::String, dynamic>>' can't be assigned to a variable of type 'dart.core::Iterable<(dart.core::String, dynamic) → dart.core::String>'.
+Reducer<State> combineTypedReducers<State, Action>(
+    Iterable<TypedReducer<State, Action>> typedReducers) {
+  return combineReducers(
+      typedReducers.map((typedReducer) => typedReducer.call));
+}

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -94,7 +94,7 @@ void main() {
       }
 
       final store = new Store<String>(
-        combineTypedReducers(getTypedReducers()),
+        combineTypedReducers<String, dynamic>(getTypedReducers()),
         initialState: 'hello',
       );
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -84,6 +84,28 @@ void main() {
     });
   });
 
+  group('combineTypedReducers', () {
+    test('works with inferred types', () {
+      List<TypedReducer<String, dynamic>> getTypedReducers() {
+        return [
+          new TypedReducer<String, TestAction1>(testAction1Reducer),
+          new TypedReducer<String, TestAction2>(testAction2Reducer),
+        ];
+      }
+
+      final store = new Store<String>(
+        combineTypedReducers(getTypedReducers()),
+        initialState: 'hello',
+      );
+
+      store.dispatch(new TestAction1());
+      expect(store.state, contains('TestAction1'));
+
+      store.dispatch(new TestAction2());
+      expect(store.state, contains('TestAction2'));
+    });
+  });
+
   group('Typed Middleware', () {
     void testAction1Middleware(
       Store<String> store,


### PR DESCRIPTION
This is needed for the times when Dart 2 can't infer types
and is unable to properly convert from `Iterable<TypedReducer<S,A>>`
to `Iterable<Reducer<S>>`, which can occur in situations like this:

```
typedef T F<T>(T t);

F<T> foo<T>(Iterable<F<T>> iter) => iter.first;

class C<T> {
  T call(T t) => t;
}

List<C<String>> getCs() => [new C<String>()];

void main() {
  foo(getCs());
}
```

That code works fine in Dart 1 but fails to compiled in Dart 2