### PR TITLE
should compare by hashCode.

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -215,9 +215,12 @@ class Store<State> {
   // the reducer, save the result, and notify any subscribers.
   NextDispatcher _createReduceAndNotify(bool distinct) {
     return (dynamic action) {
+
+      final oldHashCode = _state.hashCode;
+
       final state = reducer(_state, action);
 
-      if (distinct && state == _state) return;
+      if (distinct && state.hashCode == oldHashCode) return;
 
       _state = state;
       _changeController.add(state);


### PR DESCRIPTION
We need to receive changed state when update collection variables(List, Map, .v.v...) same reference.
All are ok if I clone collection variables are like `List.from()` but the complex time is O(n). It isn't good for the performance of large collection variables

So I get hashCode before state pass to reducers then compares with new hashCode after update collection variables.

Please check my repo to see different between redux: 3.0.0 and my contribution.

Check redux:3.0.0 please comment dependency_overrides then run flutter packages get
Check my contribution please uncomment dependency_overrides then run flutter packages get

https://github.com/phamnhuvu-dev/flutter_card_list_redux