### PR TITLE
Return type of TypedMiddleware

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -213,7 +213,7 @@ class TypedReducer<State, Action> implements ReducerClass<State> {
 /// ```
 class TypedMiddleware<State, Action> implements MiddlewareClass<State> {
   /// A [Middleware] function that only works on actions of a specific type.
-  final void Function(
+  final dynamic Function(
     Store<State> store,
     Action action,
     NextDispatcher next,


### PR DESCRIPTION
- changed the return type of TypedMiddleware from `void` to `dynamic`