### PR TITLE
Fixed unsafe link issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can combine the `DevToolsStore` with your own UI to travel in time, or use o
 
   * *Flutter* - [flutter_redux_dev_tools](https://pub.dartlang.org/packages/flutter_redux_dev_tools)
   * *Web* - [angular_redux_dev_tools](https://pub.dartlang.org/packages/angular_redux_dev_tools)
-  * *Remote* - [Redux Remote Devtools](https://pub.dartlang.org/packages/angular_redux_dev_tools). Connect your Redux.dart store to [Remote DevTools](http://extension.remotedev.io/) and debug in a web browser
+  * *Remote* - [Redux Remote Devtools](https://pub.dartlang.org/packages/angular_redux_dev_tools). Connect your Redux.dart store to [Remote DevTools](https://extension.remotedev.io/) and debug in a web browser
   
 ## Additional Utilities
 


### PR DESCRIPTION
Made a link safe to solve the problem with Dart Points in pub.dev

![grafik](https://user-images.githubusercontent.com/8026644/97851545-c86bb800-1cf5-11eb-989a-0f0325b7216c.png)

Issues that are related:
* https://github.com/fluttercommunity/redux.dart/issues/55


