### PR TITLE
const reducers

### DIFF
--- a/doc/combine_reducers.md
+++ b/doc/combine_reducers.md
@@ -198,6 +198,32 @@ AppState appStateReducer(AppState state, action) => new AppState(
 );
 ```
 
+The other way is to use `CombinedReducer` class.
+Then we can build our entire reducers tree as const object.
+
+```dart
+const itemsReducer = CombineReducer<List<String>>([
+  TypedReducer<List<String>, AddItemAction>(addItemReducer),
+  TypedReducer<List<String>, RemoveItemAction>(removeItemReducer),
+  UntypedReducer(someReducerWithDynamicAction),
+]);
+```
+
+But there is a drawback: all reducers in list must implement `ReducerClass`.
+This is caused by the fact that we can't assign [Callable Classes](https://dart.dev/guides/language/language-tour#callable-classes) to const Function:
+See also `UntypedReducer` as class wrapper for reducers with dynamic action.
+```dart
+/// introduce compile-time error
+/// A value of type 'TypedReducer<String, String>' can't be assigned to a const variable of type 'String Function(String, dynamic)'.
+const Reducer<String> reducer = TypedReducer<String, String>(null);
+
+/// Works, but we can't use reducer as const value anymore.
+final Reducer<String> reducer = const TypedReducer<String, String>(null);
+
+/// works as expected
+const ReducerClass<String> reducer = TypedReducer<String, String>(null);
+```  
+
 ### Summary, aka "all the way down the rabbit hole"
 
 We saw how to:

--- a/example/combined_reducers/index.dart
+++ b/example/combined_reducers/index.dart
@@ -52,9 +52,9 @@ AppState clickCounterReducer(AppState state, dynamic action) {
 
 void main() {
   // Create a new reducer and store for the app.
-  final combined = combineReducers<AppState>([
-    counterReducer,
-    clickCounterReducer,
+  const combined = CombinedReducer<AppState>([
+    UntypedReducer(counterReducer),
+    UntypedReducer(clickCounterReducer),
   ]);
   final store = Store<AppState>(
     combined,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -97,6 +97,11 @@ import 'package:redux/src/store.dart';
 ///   new TypedReducer<AppState, ReverseItemAction>(reverseItemsReducer),
 /// ]);
 /// ```
+///
+/// See also:
+///
+///  * [UntypedReducer] as shorthand for `TypedReducer<State, dynamic>`
+///    in contexts where classes are required
 class TypedReducer<State, Action> implements ReducerClass<State> {
   /// A [Reducer] function that only accepts an action of a specific type
   final State Function(State state, Action action) reducer;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -108,7 +108,7 @@ class TypedReducer<State, Action> implements ReducerClass<State> {
 
   /// Creates a reducer that will only be executed if the dispatched action
   /// matches the [Action] type.
-  TypedReducer(this.reducer);
+  const TypedReducer(this.reducer);
 
   @override
   State call(State state, dynamic action) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -115,6 +115,25 @@ class TypedReducer<State, Action> implements ReducerClass<State> {
   }
 }
 
+/// A convenience class for wrapping Reducers in context where classes required.
+///
+/// This allows usage when we need to combine function and class reducers
+/// in single const context.
+///
+/// See also:
+///
+///  * [CombinedReducer] - to combine reducers in const context.
+class UntypedReducer<State> implements ReducerClass<State> {
+  /// A [Reducer] function
+  final State Function(State state, dynamic action) reducer;
+
+  /// Wraps reducer function in class
+  const UntypedReducer(this.reducer);
+
+  @override
+  State call(State state, dynamic action) => reducer(state, action);
+}
+
 /// A convenience type for binding a piece of Middleware to an Action
 /// of a specific type. Allows for Type Safe Middleware and reduces boilerplate.
 ///

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -261,3 +261,48 @@ Reducer<State> combineReducers<State>(Iterable<Reducer<State>> reducers) {
     return state;
   };
 }
+
+/// Defines a utility class that combines several reducers.
+/// Works the same way as [combineReducers],
+/// but accept ReducerClass implementations.
+///
+///
+///
+/// In order to prevent having one large, monolithic reducer in your app, it can
+/// be convenient to break reducers up into smaller parts that handle more
+/// specific functionality that can be decoupled and easily tested.
+///
+/// ### Example
+///
+/// ```dart
+///     helloReducer(state, action) {
+///         return "hello";
+///     }
+///
+///     friendReducer(state, action) {
+///       return state + " friend";
+///     }
+///
+///     /// we can create const reducer if helloReducer and friendReducer
+///     /// are static or top-level functions
+///     const helloFriendReducer = CombineReducers(
+///       UntypedReducer(helloReducer),
+///       UntypedReducer(friendReducer),
+///     );
+/// ```
+class CombinedReducer<State> implements ReducerClass<State> {
+  /// A [Reducer] functions to be executed
+  final Iterable<ReducerClass<State>> reducers;
+
+  /// Creates a reducer that will try to execute supplied reducers.
+  const CombinedReducer(this.reducers);
+
+  @override
+  State call(State state, dynamic action) {
+    for (final reducer in reducers) {
+      state = reducer(state, action);
+    }
+
+    return state;
+  }
+}


### PR DESCRIPTION
Allow to build entire reducers tree as const object.

- add `CombinedReducer` class to easily combine reducers in const context
- mark `TypedReducer` constructor as const
- add `UntypedReducer` as shorthand for `TypedReducer<State, dynamic>`.
- add related tests
- add related docs in code and `doc/combine_reducers.dart`