### PR TITLE
Null safety support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 sudo: false
 dart:
-- stable
+# - stable  # this branch doesn't support stable yet
 - dev
 with_content_shell: false
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0-nullsafety.0
+
+  * Migrate to null-safety
+
 # 4.0.0+3
 
   * Update README

--- a/example/combined_reducers/index.dart
+++ b/example/combined_reducers/index.dart
@@ -4,8 +4,8 @@ import 'dart:html';
 import 'package:redux/redux.dart';
 
 void render(AppState state) {
-  querySelector('#value').innerHtml = '${state.count}';
-  querySelector('#clickValue').innerHtml = '${state.clickCount}';
+  querySelector('#value')!.innerHtml = '${state.count}';
+  querySelector('#clickValue')!.innerHtml = '${state.clickCount}';
 }
 
 class AppState {
@@ -64,21 +64,21 @@ void main() {
   render(store.state);
   store.onChange.listen(render);
 
-  querySelector('#increment').onClick.listen((_) {
+  querySelector('#increment')!.onClick.listen((_) {
     store.dispatch(AppAction.increment);
   });
 
-  querySelector('#decrement').onClick.listen((_) {
+  querySelector('#decrement')!.onClick.listen((_) {
     store.dispatch(AppAction.decrement);
   });
 
-  querySelector('#incrementIfOdd').onClick.listen((_) {
+  querySelector('#incrementIfOdd')!.onClick.listen((_) {
     if (store.state.count % 2 != 0) {
       store.dispatch(AppAction.increment);
     }
   });
 
-  querySelector('#incrementAsync').onClick.listen((_) {
+  querySelector('#incrementAsync')!.onClick.listen((_) {
     Future<Null>.delayed(Duration(milliseconds: 1000)).then((_) {
       store.dispatch(AppAction.increment);
     });

--- a/example/middleware/index.dart
+++ b/example/middleware/index.dart
@@ -4,7 +4,7 @@ import 'dart:html';
 import 'package:redux/redux.dart';
 
 void render(int state) {
-  querySelector('#value').innerHtml = '$state';
+  querySelector('#value')!.innerHtml = '$state';
 }
 
 enum Actions { increment, decrement }
@@ -47,21 +47,21 @@ void main() {
   render(store.state);
   store.onChange.listen(render);
 
-  querySelector('#increment').onClick.listen((_) {
+  querySelector('#increment')!.onClick.listen((_) {
     store.dispatch(Actions.increment);
   });
 
-  querySelector('#decrement').onClick.listen((_) {
+  querySelector('#decrement')!.onClick.listen((_) {
     store.dispatch(Actions.decrement);
   });
 
-  querySelector('#incrementIfOdd').onClick.listen((_) {
+  querySelector('#incrementIfOdd')!.onClick.listen((_) {
     if (store.state % 2 != 0) {
       store.dispatch(Actions.increment);
     }
   });
 
-  querySelector('#incrementAsync').onClick.listen((_) {
+  querySelector('#incrementAsync')!.onClick.listen((_) {
     Future<Null>.delayed(Duration(milliseconds: 1000)).then((_) {
       store.dispatch(Actions.increment);
     });

--- a/example/vanilla_counter/index.dart
+++ b/example/vanilla_counter/index.dart
@@ -4,7 +4,7 @@ import 'dart:html';
 import 'package:redux/redux.dart';
 
 void render(int state) {
-  querySelector('#value').innerHtml = '$state';
+  querySelector('#value')!.innerHtml = '$state';
 }
 
 enum Actions { increment, decrement }
@@ -35,21 +35,21 @@ void main() {
   render(store.state);
   store.onChange.listen(render);
 
-  querySelector('#increment').onClick.listen((_) {
+  querySelector('#increment')!.onClick.listen((_) {
     store.dispatch(Actions.increment);
   });
 
-  querySelector('#decrement').onClick.listen((_) {
+  querySelector('#decrement')!.onClick.listen((_) {
     store.dispatch(Actions.decrement);
   });
 
-  querySelector('#incrementIfOdd').onClick.listen((_) {
+  querySelector('#incrementIfOdd')!.onClick.listen((_) {
     if (store.state % 2 != 0) {
       store.dispatch(Actions.increment);
     }
   });
 
-  querySelector('#incrementAsync').onClick.listen((_) {
+  querySelector('#incrementAsync')!.onClick.listen((_) {
     Future<Null>.delayed(Duration(milliseconds: 1000)).then((_) {
       store.dispatch(Actions.increment);
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,12 +2,12 @@ name: redux
 maintainer: John Ryan (@johnpryan)
 description: Redux is a predictable state container for Dart and Flutter apps
 homepage: https://github.com/fluttercommunity/redux.dart
-version: 4.0.0+3
+version: 4.1.0-nullsafety.0
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0-29.10.beta <3.0.0'
 
 dev_dependencies:
-  test: '>=1.0.0 <2.0.0'
-  pedantic: ">=1.8.0+1 <2.0.0"
-  coverage: ">=0.13.0 <0.14.0"
+  test: ^1.16.0-nullsafety.12
+  pedantic: ^1.10.0-nullsafety.3
+  coverage: ^0.14.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,10 +2,10 @@ name: redux
 maintainer: John Ryan (@johnpryan)
 description: Redux is a predictable state container for Dart and Flutter apps
 homepage: https://github.com/fluttercommunity/redux.dart
-version: 4.1.0-nullsafety.0
+version: 5.0.0-nullsafety.0
 
 environment:
-  sdk: '>=2.12.0-29.10.beta <3.0.0'
+  sdk: '>=2.12.0-133.2.beta <3.0.0'
 
 dev_dependencies:
   test: ^1.16.0-nullsafety.12


### PR DESCRIPTION
This is a pretty naive migration to support null safety in `redux`.

In my opinion, it would be beneficial to have `Store._state` always be non-nullable. The issue is that the current logic in `Store.teardown()`  looks hardly replaceable.

Notes:
* It's a common practice to create a separate branch in the repo for the null safety support. If done so, I'll retarget this PR accordingly.
* Until the `coverage` package is migrated to null safety this PR shouldn't be merged.

Todo:
- [ ] Retarget the PR to a new `null-safety` branch
- [ ] CI passes
- [x] Decide on the fate of the nullable state.
- [ ] Migrate `coverage` (not required).
