### PR TITLE
add TypedMiddlewareBase abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-5.0.0
+# 5.1.0
+
+  * Added option to create typed middelware class by extending `TypedMiddlewareBase<State, Action>`
+
+# 5.0.0
 
   * Preview version, same as 5.0.0-nullsafety
 
-5.0.0-nullsafety
+# 5.0.0-nullsafety
 
   * Update to null safety
   * Drop package:coverage

--- a/README.md
+++ b/README.md
@@ -100,12 +100,22 @@ loggingMiddleware(Store<int> store, action, NextDispatcher next) {
   next(action);
 }
 
+// You can also create a middleware class bound to exact action type.
+class CallMiddleware extends TypedMiddlewareBase<State, CallAction> {
+  @override
+  dynamic dispatch(
+      Store<String> store, CallAction action, NextDispatcher next) {
+    service.call(action.phone);
+    next(action);
+  }
+}
+
 main() {
   // Create the store with our Reducer and Middleware
   final store = new Store<int>(
     counterReducer, 
     initialState: 0, 
-    middleware: [loggingMiddleware],
+    middleware: [loggingMiddleware, CallMiddleware()],
   );
 
   // Render our State right away

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -89,8 +89,18 @@ class ThunkMiddleware<State> implements MiddlewareClass<State> {
   }
 }
 
+class TypedTestMiddleware extends TypedMiddlewareBase<String, TypedTestAction> {
+  @override
+  dynamic dispatch(
+      Store<String> store, TypedTestAction action, NextDispatcher next) {
+    next('TypedTestMiddleware called');
+  }
+}
+
 class TestAction1 {}
 
 class TestAction2 {}
 
 class TestAction3 {}
+
+class TypedTestAction {}

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -108,6 +108,7 @@ void main() {
         middleware: [
           TypedMiddleware<String, TestAction1>(testAction1Middleware),
           TypedMiddleware<String, TestAction2>(testAction2Middleware),
+          TypedTestMiddleware(),
         ],
       );
 
@@ -116,6 +117,9 @@ void main() {
 
       store.dispatch(TestAction2());
       expect(store.state, 'testAction2Middleware called');
+
+      store.dispatch(TypedTestAction());
+      expect(store.state, 'TypedTestMiddleware called');
     });
 
     test(
@@ -127,6 +131,7 @@ void main() {
         initialState: initialState,
         middleware: [
           TypedMiddleware<String, TestAction1>(testAction1Middleware),
+          TypedTestMiddleware(),
         ],
       );
 


### PR DESCRIPTION
Added typed middleware base abstraction, that allows to create a typed middleware as a simple class, like ex.
```
class MyMiddleware extends TypedMiddlewareBase<State, MyAction> {
  @override
  dynamic dispatch(Store<String> store, MyAction action, NextDispatcher next) {
    ...
  }
}

final store = new Store<State>(
  middleware: [MyMiddleware()],
);
```

Or `TypedMiddlewareClass` would be better, as there is already `MiddlewareClass` abstraction. Please leave a comment, do you see it useful. It's good if you prefer to keep project fully in OOP convention.

Otherwise, if you want to extend `TypedMiddleware`, you need to create something ugly like
```
class MyMiddleware<State, Action> extends TypedMiddleware<State, Action> {
  MyMiddleware()
      : super(
          (Store<State> store, Action action, NextDispatcher next) {
            ...
          },
        );
}
```
And within constructor it is no able to use other class properties.